### PR TITLE
Refactor API and write unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+remote-executor
+hosts

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 remote-executor
 hosts
+.idea/

--- a/README.md
+++ b/README.md
@@ -7,24 +7,26 @@ The API is broken out into a sublibrary while the root of the project contains a
 
 ### Tuning with flags
 The program can be tuned with the following flags:
-- --concurrency \<number\>
+- --concurrency=\<number\>
     - default 100; the number of hosts to concurrently connect to
-- --check-hostkey=true/false
-    - default true; enable/disable remote hostkey checking
-- --parser \<string\>
+- --check-hostkey
+    - default false; specify to enable host key checking (more secure)
+- --parser=\<string\>
     - default '^([^\s]*)\b': regex to parse each line of the host list with
     - note: the regex must contain a capture group or no remote hosts will be identified
-- --user <remote user>
-    - default: $USER
-- --private-key </path/to/private/key>
-    - default: $HOME/.ssh/id_rsa
-- --known-hosts </path/to/known_hosts/file>
-    - default: %HOME/.ssh/known_hosts
-- --summarize=true/false
-    - default: false
+- --user=<remote user>
+    - default $USER
+- --private-key=</path/to/private/key>
+    - default $HOME/.ssh/id_rsa
+- --known-hosts=</path/to/known_hosts/file>
+    - default %HOME/.ssh/known_hosts
+- --summarize
+    - default false; specify to print a summary of failed hosts at the end
     - note: displays failed hosts at the end of the run
     
 ### Running
+*Note*: quotes required for commands consisting of more than 1 word
+
 CLI usage:
 
-`./remote-executor [...options] path_to_host_list cmd_to_run`
+`./remote-executor [...options] path_to_host_list "command to run"`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The program can be tuned with the following flags:
     - default: $HOME/.ssh/id_rsa
 - --known-hosts </path/to/known_hosts/file>
     - default: %HOME/.ssh/known_hosts
+- --summarize=true/false
+    - default: false
+    - note: displays failed hosts at the end of the run
     
 ### Running
 CLI usage:

--- a/README.md
+++ b/README.md
@@ -3,17 +3,25 @@ This is a small program designed to wrap remote command execution.
 
 The premise is to wrap executing a single command against a list of hosts with each host run concurrently.
 
+The API is broken out into a sublibrary while the root of the project contains a script with one possible implementation.
+
 ### Tuning with flags
 The program can be tuned with the following flags:
-- --concurrency=\<number\>
+- --concurrency \<number\>
     - default 100; the number of hosts to concurrently connect to
 - --check-hostkey=true/false
     - default true; enable/disable remote hostkey checking
-- --parser=\<string\>
-    - default '^\(\d{1-3}\.\d{1-3}\.\d{1-3\}\.\d{1-3}/)': regex to parse each line of the host list with
+- --parser \<string\>
+    - default '^([^\s]*)\b': regex to parse each line of the host list with
     - note: the regex must contain a capture group or no remote hosts will be identified
+- --user <remote user>
+    - default: $USER
+- --private-key </path/to/private/key>
+    - default: $HOME/.ssh/id_rsa
+- --known-hosts </path/to/known_hosts/file>
+    - default: %HOME/.ssh/known_hosts
     
 ### Running
 CLI usage:
 
-`./remote-executor [--concurrency=100] [--check-hostkey=true] [--parser='foobar'] path_to_host_list cmd_to_run`
+`./remote-executor [...options] path_to_host_list cmd_to_run`

--- a/api/api.go
+++ b/api/api.go
@@ -7,36 +7,50 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// WorkerPool: everything required to orchestrate running the command against remote hosts
 type WorkerPool struct {
-	nWorkers    int
-	jobs        chan string
-	results     chan Result
-	cmd         string
-	sshConfig   ssh.ClientConfig
-	wg          sync.WaitGroup
-	isReturning sync.Mutex
-	do          func()
+	numWorkers int
+	jobs       chan string
+	results    chan Result
+	cmd        string
+	sshConfig  ssh.ClientConfig
+	wg         sync.WaitGroup
+	do         func()
 }
 
-func CreatePool(size int, cmd string, config ssh.ClientConfig) *WorkerPool {
+// Result: the results of running a command against a specific host.
+// The struct and its fields are exported to enable live-streaming results to the caller.
+type Result struct {
+	Host   string
+	Output []byte
+	Err    error
+}
+
+// CreatePool: create the worker pool
+func CreatePool(poolSize, queueLength int, cmd string, config ssh.ClientConfig) *WorkerPool {
 	res := &WorkerPool{
-		nWorkers:  size,
-		jobs:      make(chan string, 2*size),
-		results:   make(chan Result, 2*size),
-		cmd:       cmd,
-		sshConfig: config,
+		numWorkers: poolSize,
+		jobs:       make(chan string, queueLength),
+		results:    make(chan Result, queueLength),
+		cmd:        cmd,
+		sshConfig:  config,
 	}
 	res.do = res.worker
 	return res
 }
 
+// ScheduleWorkers: add workers to the worker pool
 func (wp *WorkerPool) ScheduleWorkers() {
-	for i := 0; i < wp.nWorkers; i++ {
+	for i := 0; i < wp.numWorkers; i++ {
 		wp.wg.Add(1)
 		go wp.do()
 	}
 }
 
+// This is the actual worker that does the actual work. worker establishes an SSH session with the remote host and
+// runs the command on the remote host. It then waits for the result, an error if one is present, and adds a new
+// Result to the wp.results channel.
+// results will block if the channel is not made large enough or if results are not drained in a timely manner.
 func (wp *WorkerPool) worker() {
 	executor := func(host string) ([]byte, error) {
 		client, err := ssh.Dial("tcp", host, &wp.sshConfig)
@@ -65,6 +79,7 @@ func (wp *WorkerPool) worker() {
 	wp.wg.Done()
 }
 
+// ScheduleJobs: run the command against all hosts
 func (wp *WorkerPool) ScheduleJobs(hosts []string) {
 	for _, host := range hosts {
 		wp.jobs <- host
@@ -72,49 +87,38 @@ func (wp *WorkerPool) ScheduleJobs(hosts []string) {
 	close(wp.jobs)
 }
 
-func (wp *WorkerPool) Wait() {
-	wp.isReturning.Lock()
-	defer wp.isReturning.Unlock()
+func (wp *WorkerPool) wait() {
 	go func() {
 		wp.wg.Wait()
 		close(wp.results)
 	}()
-	for _ = range wp.results {
+}
+
+// Return methods: these all drain the results and should only be called once!
+// Only one return method may be called for each worker pool. Multiple calls will try to close the wp.results channel
+// twice resulting in a panic.
+
+// Wait: wait for all jobs to finish and throw away the results
+func (wp *WorkerPool) Wait() {
+	wp.wait()
+	for range wp.results {
 	}
 }
 
+// WaitAndReturnResults: wait for all jobs to finish and return the collected results
 func (wp *WorkerPool) WaitAndReturnResults() []Result {
+	wp.wait()
 	var results []Result
-	wp.isReturning.Lock()
-	defer wp.isReturning.Unlock()
-
-	go func() {
-		wp.wg.Wait()
-		close(wp.results)
-	}()
 	for res := range wp.results {
 		results = append(results, res)
 	}
-
 	return results
 }
 
+// StreamResults: stream live results back to the caller as soon as they are ready
 func (wp *WorkerPool) StreamResults(receiver chan<- Result) {
-	wp.isReturning.Lock()
-	defer wp.isReturning.Unlock()
-
-	go func() {
-		wp.wg.Wait()
-		close(wp.results)
-	}()
+	wp.wait()
 	for res := range wp.results {
 		receiver <- res
 	}
-
-}
-
-type Result struct {
-	Host   string
-	Output []byte
-	Err    error
 }

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -10,8 +11,7 @@ import (
 // WorkerPool: everything required to orchestrate running the command against remote hosts
 type WorkerPool struct {
 	numWorkers int
-	jobs       chan string
-	results    chan Result
+	jobs       chan JobResult
 	cmd        string
 	sshConfig  ssh.ClientConfig
 	wg         sync.WaitGroup
@@ -26,12 +26,17 @@ type Result struct {
 	Err    error
 }
 
+type JobResult struct {
+	host   string
+	result *Result
+	done   chan struct{}
+}
+
 // CreatePool: create the worker pool
-func CreatePool(poolSize, queueLength int, cmd string, config ssh.ClientConfig) *WorkerPool {
+func CreatePool(poolSize int, cmd string, config ssh.ClientConfig) *WorkerPool {
 	res := &WorkerPool{
 		numWorkers: poolSize,
-		jobs:       make(chan string, queueLength),
-		results:    make(chan Result, queueLength),
+		jobs:       make(chan JobResult),
 		cmd:        cmd,
 		sshConfig:  config,
 	}
@@ -47,78 +52,54 @@ func (wp *WorkerPool) ScheduleWorkers() {
 	}
 }
 
+// Connect to the remote server, execute the command, and return the output.
+func (wp *WorkerPool) executor(host string) ([]byte, error) {
+	client, err := ssh.Dial("tcp", host, &wp.sshConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not dial: %v", err)
+	}
+
+	sess, err := client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create session: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	return sess.CombinedOutput(wp.cmd)
+}
+
 // This is the actual worker that does the actual work. worker establishes an SSH session with the remote host and
 // runs the command on the remote host. It then waits for the result, an error if one is present, and adds a new
 // Result to the wp.results channel.
 // results will block if the channel is not made large enough or if results are not drained in a timely manner.
 func (wp *WorkerPool) worker() {
-	executor := func(host string) ([]byte, error) {
-		client, err := ssh.Dial("tcp", host, &wp.sshConfig)
-		if err != nil {
-			return nil, fmt.Errorf("could not dial: %v", err)
-		}
-
-		sess, err := client.NewSession()
-		if err != nil {
-			return nil, fmt.Errorf("unable to create session: %v", err)
-		}
-		defer func() { _ = sess.Close() }()
-
-		return sess.CombinedOutput(wp.cmd)
-	}
-
-	for host := range wp.jobs {
-		output, err := executor(host)
-		wp.results <- Result{
-			host,
-			output,
-			err,
-		}
+	for job := range wp.jobs {
+		output, err := wp.executor(job.host)
+		job.result.Host = job.host
+		job.result.Output = output
+		job.result.Err = err
+		close(job.done)
 	}
 
 	wp.wg.Done()
 }
 
-// ScheduleJobs: run the command against all hosts
-func (wp *WorkerPool) ScheduleJobs(hosts []string) {
-	for _, host := range hosts {
-		wp.jobs <- host
+// RunJob: run the remote command against the specified host and return the Result.
+// Return an error if the context is cancelled before the job finishes.
+func (wp *WorkerPool) RunJob(ctx context.Context, host string) (Result, error) {
+	res := new(Result)
+	done := make(chan struct{})
+
+	select {
+	case wp.jobs <- JobResult{host, res, done}:
+	case <-ctx.Done():
+		return Result{}, nil
 	}
-	close(wp.jobs)
-}
 
-func (wp *WorkerPool) wait() {
-	go func() {
-		wp.wg.Wait()
-		close(wp.results)
-	}()
-}
-
-// Return methods: these all drain the results and should only be called once!
-// Only one return method may be called for each worker pool. Multiple calls will try to close the wp.results channel
-// twice resulting in a panic.
-
-// Wait: wait for all jobs to finish and throw away the results
-func (wp *WorkerPool) Wait() {
-	wp.wait()
-	for range wp.results {
-	}
-}
-
-// WaitAndReturnResults: wait for all jobs to finish and return the collected results
-func (wp *WorkerPool) WaitAndReturnResults() []Result {
-	wp.wait()
-	var results []Result
-	for res := range wp.results {
-		results = append(results, res)
-	}
-	return results
-}
-
-// StreamResults: stream live results back to the caller as soon as they are ready
-func (wp *WorkerPool) StreamResults(receiver chan<- Result) {
-	wp.wait()
-	for res := range wp.results {
-		receiver <- res
+	select {
+	case <-done:
+		return *res, nil
+	case <-ctx.Done():
+		return Result{}, nil
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"fmt"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type WorkerPool struct {
+	nWorkers    int
+	jobs        chan string
+	results     chan Result
+	done        chan bool
+	cmd         string
+	sshConfig   ssh.ClientConfig
+	wg          sync.WaitGroup
+	isReturning sync.Mutex
+}
+
+func CreatePool(size int, cmd string, config ssh.ClientConfig) *WorkerPool {
+	return &WorkerPool{
+		nWorkers:  size,
+		jobs:      make(chan string, 2*size),
+		results:   make(chan Result, 2*size),
+		done:      make(chan bool),
+		cmd:       cmd,
+		sshConfig: config,
+	}
+}
+
+func (wp *WorkerPool) ScheduleWorkers() {
+	for i := 0; i < wp.nWorkers; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+	wp.wg.Wait()
+	wp.done <- true
+}
+
+func (wp *WorkerPool) worker() {
+	executor := func(host string) ([]byte, error) {
+		client, err := ssh.Dial("tcp", host, &wp.sshConfig)
+		if err != nil {
+			return nil, fmt.Errorf("could not dial: %v", err)
+		}
+
+		sess, err := client.NewSession()
+		if err != nil {
+			return nil, fmt.Errorf("unable to create session: %v", err)
+		}
+		defer func() { _ = sess.Close() }()
+
+		return sess.CombinedOutput(wp.cmd)
+	}
+
+	for host := range wp.jobs {
+		output, err := executor(host)
+		wp.results <- Result{
+			host,
+			output,
+			err,
+		}
+	}
+
+	wp.wg.Done()
+}
+
+func (wp *WorkerPool) ScheduleJobs(hosts []string) {
+	for _, host := range hosts {
+		wp.jobs <- host
+	}
+	close(wp.jobs)
+}
+
+func (wp *WorkerPool) WaitAndReturnResults() []Result {
+	var results []Result
+	wp.isReturning.Lock()
+	defer wp.isReturning.Unlock()
+
+	for {
+		select {
+		case res := <-wp.results:
+			results = append(results, res)
+		case <-wp.done:
+			return results
+		}
+	}
+}
+
+func (wp *WorkerPool) StreamResults(receiver chan<- Result) {
+	wp.isReturning.Lock()
+	defer wp.isReturning.Unlock()
+
+	for {
+		select {
+		case res := <-wp.results:
+			receiver <- res
+		case <-wp.done:
+			close(receiver)
+			return
+		}
+	}
+}
+
+type Result struct {
+	Host   string
+	Output []byte
+	Err    error
+}

--- a/api/api.go
+++ b/api/api.go
@@ -15,7 +15,7 @@ type WorkerPool struct {
 	sshConfig   ssh.ClientConfig
 	wg          sync.WaitGroup
 	isReturning sync.Mutex
-	do func()
+	do          func()
 }
 
 func CreatePool(size int, cmd string, config ssh.ClientConfig) *WorkerPool {
@@ -75,11 +75,12 @@ func (wp *WorkerPool) ScheduleJobs(hosts []string) {
 func (wp *WorkerPool) Wait() {
 	wp.isReturning.Lock()
 	defer wp.isReturning.Unlock()
-	go func(){
+	go func() {
 		wp.wg.Wait()
 		close(wp.results)
 	}()
-	for _ = range wp.results {}
+	for _ = range wp.results {
+	}
 }
 
 func (wp *WorkerPool) WaitAndReturnResults() []Result {
@@ -87,7 +88,7 @@ func (wp *WorkerPool) WaitAndReturnResults() []Result {
 	wp.isReturning.Lock()
 	defer wp.isReturning.Unlock()
 
-	go func(){
+	go func() {
 		wp.wg.Wait()
 		close(wp.results)
 	}()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 )
 
-var tests = map[string]struct{
+var tests = map[string]struct {
 	iterations int
-	nWorkers int
-	hosts []string
+	nWorkers   int
+	hosts      []string
 }{
 	"small pool few jobs": {
 		10,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,9 +1,21 @@
 package api
 
 import (
+	"bytes"
+	"context"
+	cRand "crypto/rand"
+	"crypto/rsa"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log"
 	"math/rand"
-	"sort"
+	"net"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -40,25 +52,36 @@ var tests = map[string]struct {
 func TestMainFlow(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			var mu sync.Mutex
 			var good, bad float64
 			var toLog string
 			for i := 0; i < test.iterations; i++ {
-				wp := CreatePool(test.nWorkers, len(test.hosts), "noop", ssh.ClientConfig{})
+				wp := CreatePool(test.nWorkers, "noop", ssh.ClientConfig{})
 				wp.do = wp.testWorker
 				wp.ScheduleWorkers()
-				go wp.ScheduleJobs(test.hosts)
-				{
-					var got results = wp.WaitAndReturnResults()
-					want := resultsFromHosts(test.hosts)
-					sort.Sort(got)
-					sort.Sort(want)
-					if diff := cmp.Diff(got, want); diff != "" {
-						bad++
-						toLog = diff
-					} else {
-						good++
-					}
+				var wg sync.WaitGroup
+				for _, host := range test.hosts {
+					wg.Add(1)
+					go func(h string) {
+						got, err := wp.RunJob(context.Background(), h)
+						if err != nil {
+							t.Errorf("RunJob: %v", err)
+						}
+						want := Result{
+							h,
+							[]byte("test"),
+							nil,
+						}
+						if diff := cmp.Diff(got, want); diff != "" {
+							mu.Lock()
+							bad++
+							toLog = diff
+							mu.Unlock()
+						}
+						wg.Done()
+					}(host)
 				}
+				wg.Wait()
 			}
 			if bad != 0 {
 				percentPass := 100.0 * (good / (good + bad))
@@ -68,16 +91,135 @@ func TestMainFlow(t *testing.T) {
 	}
 }
 
-func resultsFromHosts(hosts []string) results {
-	var res results
-	for _, host := range hosts {
-		res = append(res, Result{
-			host,
-			[]byte("test"),
-			nil,
-		})
+func TestExecutor(t *testing.T) {
+	b := make([]byte, 32)
+	_, err := cRand.Read(b)
+	if err != nil {
+		t.Fatalf("crypto/rand.Read: %v", err)
 	}
-	return res
+
+	clientConf := ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password(string(b))},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	done := make(chan struct{})
+	ready := make(chan struct{})
+	go func() {
+		if err := newSSHServer(b, done, ready); err != nil {
+			t.Fatalf("issue running SSH server: %v", err)
+		}
+	}()
+	<-ready
+	wp1 := CreatePool(10, "test", clientConf)
+	output, err := wp1.executor("localhost:2022")
+	if err != nil {
+		t.Fatalf("executor failed: %v", err)
+	}
+	if got, want := string(output), "success!"; got != want {
+		t.Fatalf("executor returned %v, want %v", got, want)
+	}
+
+	wp2 := CreatePool(10, "fail", clientConf)
+	output, err = wp2.executor("localhost:2022")
+	if err != nil && err.Error() != "Process exited with status 1" {
+		t.Fatalf("executor failed: %v", err)
+	}
+	if got, want := string(output), "failed!"; got != want {
+		t.Fatalf("executor returned %v, want %v", got, want)
+	}
+	close(done)
+}
+
+//func newSSHServer(serverPass []byte, done <- chan struct{}) (*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+func newSSHServer(serverPass []byte, done <-chan struct{}, ready chan<- struct{}) error {
+	serverConfig := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			if c.User() == "test" && subtle.ConstantTimeCompare(serverPass, pass) == 1 {
+				return nil, nil
+			} else {
+				return nil, errors.New("unauthorized")
+			}
+		},
+	}
+
+	privateKey, _ := rsa.GenerateKey(cRand.Reader, 2048)
+	privateKeyPEM := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	private, err := ssh.ParsePrivateKey(pem.EncodeToMemory(&privateKeyPEM))
+	if err != nil {
+		return fmt.Errorf("ParsePrivateKey: %v", err)
+	}
+	serverConfig.AddHostKey(private)
+
+	listener, err := net.Listen("tcp", "localhost:2022")
+	if err != nil {
+		return fmt.Errorf("net.Listen: %v", err)
+	}
+	close(ready)
+
+	for {
+		// blocks waiting for connection
+		nConn, err := listener.Accept()
+		if err != nil {
+			return fmt.Errorf("listener.Accept: %v", err)
+		}
+
+		conn, chans, reqs, err := ssh.NewServerConn(nConn, serverConfig)
+		if err != nil {
+			return fmt.Errorf("NewServerConn: %v", err)
+		}
+
+		go ssh.DiscardRequests(reqs)
+
+		select {
+		case newChannel := <-chans:
+			if newChannel.ChannelType() != "session" {
+				newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return fmt.Errorf("could not accept channel: %v", err)
+			}
+
+			go func(in <-chan *ssh.Request) {
+				defer channel.Close()
+				for req := range in {
+					switch req.Type {
+					case "exec":
+						cmd := req.Payload[4:]
+						var output, exitStatus []byte
+						if string(cmd) == "test" {
+							output = []byte("success!")
+							exitStatus = []byte{0, 0, 0, 0}
+						} else {
+							output = []byte("failed!")
+							exitStatus = []byte{0, 0, 0, 1}
+						}
+						if err := req.Reply(true, nil); err != nil {
+							log.Fatalf("could not reply to request: %v", err)
+						}
+
+						if _, err := io.Copy(channel, bytes.NewReader(output)); err != nil {
+							log.Fatalf("io.Copy: %v", err)
+						}
+
+						if ok, err := channel.SendRequest("exit-status", false, exitStatus); err != nil {
+							log.Fatalf("could not send request to channel: %v, ok: %v", err, ok)
+						}
+						return
+					}
+				}
+			}(requests)
+		case <-done:
+			return conn.Close()
+		}
+	}
 }
 
 func randHosts(n int) []string {
@@ -90,26 +232,10 @@ func randHosts(n int) []string {
 
 func (wp *WorkerPool) testWorker() {
 	for job := range wp.jobs {
-		//time.Sleep(10 * time.Millisecond)
-		wp.results <- Result{
-			job,
-			[]byte("test"),
-			nil,
-		}
+		job.result.Host = job.host
+		job.result.Output = []byte("test")
+		job.result.Err = nil
+		job.done <- struct{}{}
 	}
 	wp.wg.Done()
-}
-
-type results []Result
-
-func (r results) Len() int {
-	return len(r)
-}
-
-func (r results) Less(i, j int) bool {
-	return r[i].Host < r[j].Host
-}
-
-func (r results) Swap(i, j int) {
-	r[i], r[j] = r[j], r[i]
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/crypto/ssh"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+var tests = map[string]struct{
+	iterations int
+	nWorkers int
+	hosts []string
+}{
+	"small pool few jobs": {
+		10,
+		5,
+		randHosts(5),
+	},
+	"med pool few jobs": {
+		10,
+		100,
+		randHosts(5),
+	},
+	"small pool many jobs": {
+		10,
+		5,
+		randHosts(500),
+	},
+	"med pool many jobs": {
+		10,
+		100,
+		randHosts(500),
+	},
+}
+
+func TestMainFlow(t *testing.T) {
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var good, bad float64
+			var toLog string
+			for i := 0; i < test.iterations; i++ {
+				wp := CreatePool(test.nWorkers, "noop", ssh.ClientConfig{})
+				wp.do = wp.testWorker
+				wp.ScheduleWorkers()
+				go wp.ScheduleJobs(test.hosts)
+				{
+					var got results = wp.WaitAndReturnResults()
+					want := resultsFromHosts(test.hosts)
+					sort.Sort(got)
+					sort.Sort(want)
+					if diff := cmp.Diff(got, want); diff != "" {
+						bad++
+						toLog = diff
+					} else {
+						good++
+					}
+				}
+			}
+			if bad != 0 {
+				percentPass := 100.0 * (good / (good + bad))
+				t.Fatalf("%g percent of attempts correct, last diff: %s", percentPass, toLog)
+			}
+		})
+	}
+}
+
+func resultsFromHosts(hosts []string) results {
+	var res results
+	for _, host := range hosts {
+		res = append(res, Result{
+			host,
+			[]byte("test"),
+			nil,
+		})
+	}
+	return res
+}
+
+func randHosts(n int) []string {
+	var hosts []string
+	for i := 0; i < n; i++ {
+		hosts = append(hosts, strconv.Itoa(rand.Int()))
+	}
+	return hosts
+}
+
+func (wp *WorkerPool) testWorker() {
+	for job := range wp.jobs {
+		//time.Sleep(10 * time.Millisecond)
+		wp.results <- Result{
+			job,
+			[]byte("test"),
+			nil,
+		}
+	}
+	wp.wg.Done()
+}
+
+type results []Result
+
+func (r results) Len() int {
+	return len(r)
+}
+
+func (r results) Less(i, j int) bool {
+	return r[i].Host < r[j].Host
+}
+
+func (r results) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,12 +1,13 @@
 package api
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"golang.org/x/crypto/ssh"
 	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/crypto/ssh"
 )
 
 var tests = map[string]struct {
@@ -42,7 +43,7 @@ func TestMainFlow(t *testing.T) {
 			var good, bad float64
 			var toLog string
 			for i := 0; i < test.iterations; i++ {
-				wp := CreatePool(test.nWorkers, "noop", ssh.ClientConfig{})
+				wp := CreatePool(test.nWorkers, len(test.hosts), "noop", ssh.ClientConfig{})
 				wp.do = wp.testWorker
 				wp.ScheduleWorkers()
 				go wp.ScheduleJobs(test.hosts)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/basilnsage/remote-executor
 go 1.15
 
 require (
+	github.com/google/go-cmp v0.5.4
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/basilnsage/remote-executor
+
+go 1.15
+
+require (
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -12,4 +12,5 @@ golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
+golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -10,3 +12,4 @@ golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -1,46 +1,29 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
-	"strings"
-	"sync"
 
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
+	"github.com/basilnsage/remote-executor/api"
+	"github.com/basilnsage/remote-executor/utils"
 )
 
-const usage = "./remote-executor [--concurrency=100] [--check-hostkey=true] [--parser='foobar'] path_to_host_list cmd_to_run"
-
-type config struct {
-	numWorkers      int
-	hostkeyCallback ssh.HostKeyCallback
-	hostlist        string
-	sshPort string
-	hostlistRegex   *regexp.Regexp
-	remoteCmd       string
-	remoteUser      string
-	privateKeyFile  string
-}
-
 var (
-	numWorkers   int
-	checkHostKey bool
-	regexExpr    string
-	remoteUser   string
-	pkeyPath     string
-	summarize bool
-	port string
+	numWorkers     int
+	checkHostKey   bool
+	regexExpr      string
+	remoteUser     string
+	pkeyPath       string
+	knownHostsPath string
 )
 
 func init() {
 	homeDir, _ := os.LookupEnv("HOME")
 	userName, _ := os.LookupEnv("USER")
+
 	flag.IntVar(&numWorkers, "concurrency", 100, "size of worker pool")
 	flag.BoolVar(&checkHostKey, "check-hostkey", true, "check remote host key")
 	flag.StringVar(
@@ -56,221 +39,64 @@ func init() {
 		fmt.Sprintf("%s/.ssh/id_rsa", homeDir),
 		"ssh private key to use",
 	)
-	flag.BoolVar(&summarize, "summarize", false, "report failed hosts at the end of the run")
-	flag.StringVar(&port, "remote-port", "22", "remote server's SSH port")
-}
-
-// parseFlags: parse CLI flags to tune runetime behavior
-func parseFlags(args []string) (*config, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("need 2 positional arguments, usage: %v", usage)
-	}
-
-	var callback ssh.HostKeyCallback
-	if checkHostKey {
-		homeDir, _ := os.LookupEnv("HOME")
-		if hostkeyCallback, err := knownhosts.New(fmt.Sprintf("%s/.ssh/known_hosts", homeDir)); err != nil {
-			return nil, fmt.Errorf("knowhosts.New: %v", err)
-		} else {
-			callback = hostkeyCallback
-		}
-	} else {
-		callback = ssh.InsecureIgnoreHostKey()
-	}
-	re, err := regexp.Compile(regexExpr)
-	if err != nil {
-		return nil, fmt.Errorf("regexp.Compile: %v", err)
-	}
-
-	return &config{
-		numWorkers:      numWorkers,
-		hostkeyCallback: callback,
-		hostlist:        args[0],
-		sshPort: port,
-		hostlistRegex:   re,
-		remoteCmd:       args[1],
-		remoteUser:      remoteUser,
-		privateKeyFile:  pkeyPath,
-	}, nil
-}
-
-type result struct {
-	host string
-	output []byte
-	err error
-}
-
-type remoteCommand struct {
-	cmd       string
-	sshConfig ssh.ClientConfig
-	jobs      chan string
-	results   chan result
-	errors    chan error
-}
-
-func newRemoteCommand(c *config) (*remoteCommand, error) {
-	// parse private key to create a public key auth mechanism
-	pkey, err := ioutil.ReadFile(c.privateKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read private key file: %v", err)
-	}
-	signer, err := ssh.ParsePrivateKey(pkey)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse private key: %v", err)
-	}
-
-	return &remoteCommand{
-		cmd: c.remoteCmd,
-		sshConfig: ssh.ClientConfig{
-			User: c.remoteUser,
-			Auth: []ssh.AuthMethod{
-				ssh.PublicKeys(signer),
-			},
-			HostKeyCallback: c.hostkeyCallback,
-		},
-		jobs:    make(chan string, 2*c.numWorkers),
-		results: make(chan result, 2*c.numWorkers),
-		errors:  make(chan error, 2*c.numWorkers),
-	}, nil
-}
-
-// acceptHosts: listen for hosts to run the remote command against
-// report errors, successes back into the remoteCommand's channels
-func (r *remoteCommand) worker(wg *sync.WaitGroup) {
-	executor := func(host string) ([]byte, error) {
-		client, err := ssh.Dial("tcp", host, &r.sshConfig)
-		if err != nil {
-			return nil, fmt.Errorf("could not dial: %v", err)
-		}
-
-		sess, err := client.NewSession()
-		if err != nil {
-			return nil, fmt.Errorf("unable to create session: %v", err)
-		}
-		defer func() { _ = sess.Close() }()
-
-		return sess.CombinedOutput(r.cmd)
-	}
-	for host := range r.jobs {
-		output, err := executor(host)
-		r.results <- result{
-			host,
-			output,
-			err,
-		}
-	}
-	wg.Done()
-}
-
-// queueWorkers: start worker goroutines that will execute the remote command
-func (r *remoteCommand) queueWorkers(n int, done chan<- bool) {
-	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go r.worker(&wg)
-	}
-	wg.Wait()
-	done <- true
-}
-
-// schedule: take in a list of hosts and schedule running the remote command
-// against each host
-func (r *remoteCommand) schedule(hosts []string, remotePort string) {
-	for _, host := range hosts {
-		r.jobs <- fmt.Sprintf("%s:%s", host, remotePort)
-	}
-	close(r.jobs)
-}
-
-// parseHosts: parse the provided host list to identify hosts to run the remote command against
-func parseHosts(hostFile string, re *regexp.Regexp) ([]string, error) {
-	hosts := make([]string, 0, 0)
-
-	file, err := os.Open(hostFile)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open host list file: %v", err)
-	}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		matches := re.FindSubmatch(scanner.Bytes())
-		if matches != nil {
-			hosts = append(hosts, string(matches[1]))
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scanner error: %v", err)
-	}
-	return hosts, nil
-}
-
-type logger struct {
-	l  *log.Logger
-	mu sync.Mutex
-}
-
-func (l *logger) info(msg string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.l.Printf("INFO: %s", msg)
-}
-
-func (l *logger) error(msg string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.l.Printf("ERROR: %s", msg)
+	flag.StringVar(
+		&knownHostsPath,
+		"known-hosts",
+		fmt.Sprintf("%s/.ssh/known_hosts", homeDir),
+		"path to known hosts file",
+	)
 }
 
 func main() {
-	l := &logger{
-		l: log.New(os.Stdout, "remote-executor: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
+	syncLogger := utils.SyncLogger{
+		Logger: log.New(os.Stdout, "remote-executor: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
 	}
+	syncLogger.Info("starting new remote executor run")
 
-	// parse flags and create configs
+	// parse flags and check positional arguments
 	flag.Parse()
-	conf, err := parseFlags(flag.Args())
+	args := flag.Args()
+	if len(args) != 2 {
+		syncLogger.Fatal(fmt.Sprintf("need 2 positional arugments, found: %d", len(args)))
+	}
+	hostList := args[0]
+	remoteCommand := args[1]
+
+	// create ssh client config
+	sshConf, err := utils.NewSSHConfig(checkHostKey, knownHostsPath, pkeyPath, remoteUser)
 	if err != nil {
-		log.Fatalf("unable to parse flags: %v", err)
+		syncLogger.Fatal(fmt.Sprintf("unable to parse flags: %v", err))
 	}
 
-	// create a new remoteCommand object to manage execution
-	rc, err := newRemoteCommand(conf)
+	// compile re
+	re, err := regexp.Compile(regexExpr)
 	if err != nil {
-		log.Fatalf("unable to initialize the remote command: %v", err)
+		syncLogger.Fatal(fmt.Sprintf("unable to compile regex: %v", err))
 	}
 
-	// parse host list
-	hosts, err := parseHosts(conf.hostlist, conf.hostlistRegex)
+	// parse the host list
+	hosts, err := utils.ParseHostsList(hostList, re, utils.Append22)
 	if err != nil {
-		log.Fatalf("unable to parse host list: %v", err)
+		syncLogger.Fatal(fmt.Sprintf("unable to parse host list: %v", err))
 	}
+
+	// create worker pool
+	pool := api.CreatePool(numWorkers, remoteCommand, sshConf)
 
 	// schedule workers
-	done := make(chan bool)
-	l.info("queueing workers")
-	go rc.queueWorkers(conf.numWorkers, done)
+	go pool.ScheduleWorkers()
 
-	// create jobs
-	l.info("scheduling jobs")
-	go rc.schedule(hosts, conf.sshPort)
+	// schedule jobs; i.e. run remoteCommand against hosts
+	go pool.ScheduleJobs(hosts)
 
-	// parse results -- block on this
-	failed := make([]string, 0)
-	l.info("waiting for results")
-	for {
-		select {
-		case res := <-rc.results:
-			if res.err != nil {
-				l.error(fmt.Sprintf("%s\n%s", res.err.Error(), string(res.output)))
-				failed = append(failed, res.host)
-			} else {
-				l.info(string(res.output))
-			}
-		case <-done:
-			if summarize && len(failed) > 0 {
-				l.info(fmt.Sprintf("failed hosts:\n%s", strings.Join(failed, "\n")))
-			}
-			l.info("exiting...")
-			return
+	// collect and log results
+	results := make(chan api.Result, len(hosts))
+	go pool.StreamResults(results)
+	for res := range results {
+		if res.Err != nil {
+			syncLogger.Error(fmt.Sprintf("%s\n%s\n%s", res.Host, res.Err.Error(), string(res.Output)))
+		} else {
+			syncLogger.Info(string(res.Output))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+const usage = "./remote-executor [--concurrency=100] [--check-hostkey=true] [--parser='foobar'] path_to_host_list cmd_to_run"
+
+type config struct {
+	numWorkers      int
+	hostkeyCallback ssh.HostKeyCallback
+	hostlist        string
+	sshPort string
+	hostlistRegex   *regexp.Regexp
+	remoteCmd       string
+	remoteUser      string
+	privateKeyFile  string
+}
+
+var (
+	numWorkers   int
+	checkHostKey bool
+	regexExpr    string
+	remoteUser   string
+	pkeyPath     string
+	summarize bool
+	port string
+)
+
+func init() {
+	homeDir, _ := os.LookupEnv("HOME")
+	userName, _ := os.LookupEnv("USER")
+	flag.IntVar(&numWorkers, "concurrency", 100, "size of worker pool")
+	flag.BoolVar(&checkHostKey, "check-hostkey", true, "check remote host key")
+	flag.StringVar(
+		&regexExpr,
+		"parser",
+		`^(.*)\b`,
+		"regex used to parse host list",
+	)
+	flag.StringVar(&remoteUser, "user", userName, "remote user")
+	flag.StringVar(
+		&pkeyPath,
+		"private-key",
+		fmt.Sprintf("%s/.ssh/id_rsa", homeDir),
+		"ssh private key to use",
+	)
+	flag.BoolVar(&summarize, "summarize", false, "report failed hosts at the end of the run")
+	flag.StringVar(&port, "remote-port", "22", "remote server's SSH port")
+}
+
+// parseFlags: parse CLI flags to tune runetime behavior
+func parseFlags(args []string) (*config, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("need 2 positional arguments, usage: %v", usage)
+	}
+
+	var callback ssh.HostKeyCallback
+	if checkHostKey {
+		homeDir, _ := os.LookupEnv("HOME")
+		if hostkeyCallback, err := knownhosts.New(fmt.Sprintf("%s/.ssh/known_hosts", homeDir)); err != nil {
+			return nil, fmt.Errorf("knowhosts.New: %v", err)
+		} else {
+			callback = hostkeyCallback
+		}
+	} else {
+		callback = ssh.InsecureIgnoreHostKey()
+	}
+	re, err := regexp.Compile(regexExpr)
+	if err != nil {
+		return nil, fmt.Errorf("regexp.Compile: %v", err)
+	}
+
+	return &config{
+		numWorkers:      numWorkers,
+		hostkeyCallback: callback,
+		hostlist:        args[0],
+		sshPort: port,
+		hostlistRegex:   re,
+		remoteCmd:       args[1],
+		remoteUser:      remoteUser,
+		privateKeyFile:  pkeyPath,
+	}, nil
+}
+
+type result struct {
+	host string
+	output []byte
+	err error
+}
+
+type remoteCommand struct {
+	cmd       string
+	sshConfig ssh.ClientConfig
+	jobs      chan string
+	results   chan result
+	errors    chan error
+}
+
+func newRemoteCommand(c *config) (*remoteCommand, error) {
+	// parse private key to create a public key auth mechanism
+	pkey, err := ioutil.ReadFile(c.privateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read private key file: %v", err)
+	}
+	signer, err := ssh.ParsePrivateKey(pkey)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse private key: %v", err)
+	}
+
+	return &remoteCommand{
+		cmd: c.remoteCmd,
+		sshConfig: ssh.ClientConfig{
+			User: c.remoteUser,
+			Auth: []ssh.AuthMethod{
+				ssh.PublicKeys(signer),
+			},
+			HostKeyCallback: c.hostkeyCallback,
+		},
+		jobs:    make(chan string, 2*c.numWorkers),
+		results: make(chan result, 2*c.numWorkers),
+		errors:  make(chan error, 2*c.numWorkers),
+	}, nil
+}
+
+// acceptHosts: listen for hosts to run the remote command against
+// report errors, successes back into the remoteCommand's channels
+func (r *remoteCommand) worker(wg *sync.WaitGroup) {
+	executor := func(host string) ([]byte, error) {
+		client, err := ssh.Dial("tcp", host, &r.sshConfig)
+		if err != nil {
+			return nil, fmt.Errorf("could not dial: %v", err)
+		}
+
+		sess, err := client.NewSession()
+		if err != nil {
+			return nil, fmt.Errorf("unable to create session: %v", err)
+		}
+		defer func() { _ = sess.Close() }()
+
+		return sess.CombinedOutput(r.cmd)
+	}
+	for host := range r.jobs {
+		output, err := executor(host)
+		r.results <- result{
+			host,
+			output,
+			err,
+		}
+	}
+	wg.Done()
+}
+
+// queueWorkers: start worker goroutines that will execute the remote command
+func (r *remoteCommand) queueWorkers(n int, done chan<- bool) {
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go r.worker(&wg)
+	}
+	wg.Wait()
+	done <- true
+}
+
+// schedule: take in a list of hosts and schedule running the remote command
+// against each host
+func (r *remoteCommand) schedule(hosts []string, remotePort string) {
+	for _, host := range hosts {
+		r.jobs <- fmt.Sprintf("%s:%s", host, remotePort)
+	}
+	close(r.jobs)
+}
+
+// parseHosts: parse the provided host list to identify hosts to run the remote command against
+func parseHosts(hostFile string, re *regexp.Regexp) ([]string, error) {
+	hosts := make([]string, 0, 0)
+
+	file, err := os.Open(hostFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open host list file: %v", err)
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		matches := re.FindSubmatch(scanner.Bytes())
+		if matches != nil {
+			hosts = append(hosts, string(matches[1]))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanner error: %v", err)
+	}
+	return hosts, nil
+}
+
+type logger struct {
+	l  *log.Logger
+	mu sync.Mutex
+}
+
+func (l *logger) info(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Printf("INFO: %s", msg)
+}
+
+func (l *logger) error(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Printf("ERROR: %s", msg)
+}
+
+func main() {
+	l := &logger{
+		l: log.New(os.Stdout, "remote-executor: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
+	}
+
+	// parse flags and create configs
+	flag.Parse()
+	conf, err := parseFlags(flag.Args())
+	if err != nil {
+		log.Fatalf("unable to parse flags: %v", err)
+	}
+
+	// create a new remoteCommand object to manage execution
+	rc, err := newRemoteCommand(conf)
+	if err != nil {
+		log.Fatalf("unable to initialize the remote command: %v", err)
+	}
+
+	// parse host list
+	hosts, err := parseHosts(conf.hostlist, conf.hostlistRegex)
+	if err != nil {
+		log.Fatalf("unable to parse host list: %v", err)
+	}
+
+	// schedule workers
+	done := make(chan bool)
+	l.info("queueing workers")
+	go rc.queueWorkers(conf.numWorkers, done)
+
+	// create jobs
+	l.info("scheduling jobs")
+	go rc.schedule(hosts, conf.sshPort)
+
+	// parse results -- block on this
+	failed := make([]string, 0)
+	l.info("waiting for results")
+	for {
+		select {
+		case res := <-rc.results:
+			if res.err != nil {
+				l.error(fmt.Sprintf("%s\n%s", res.err.Error(), string(res.output)))
+				failed = append(failed, res.host)
+			} else {
+				l.info(string(res.output))
+			}
+		case <-done:
+			if summarize && len(failed) > 0 {
+				l.info(fmt.Sprintf("failed hosts:\n%s", strings.Join(failed, "\n")))
+			}
+			l.info("exiting...")
+			return
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	_ = t
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"testing"
-)
-
-func TestFoo(t *testing.T) {
-	_ = t
-}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -79,7 +79,7 @@ func Append22(host string) string {
 	if len(parts) == 1 && parts[0] != "" {
 		res = fmt.Sprintf("%s:%d", host, 22)
 	} else if len(parts) > 1 {
-		last := parts[len(parts) - 1]
+		last := parts[len(parts)-1]
 		switch {
 		case last == "":
 			res = fmt.Sprintf("%s%d", host, 22)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,104 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// SSH utilities
+
+func NewSSHConfig(checkHostKey bool, knownHostsFile, privateKeyFile, remoteUser string) (ssh.ClientConfig, error) {
+	var conf ssh.ClientConfig
+	var callback ssh.HostKeyCallback
+
+	if checkHostKey {
+		if cb, err := knownhosts.New(knownHostsFile); err != nil {
+			return conf, fmt.Errorf("knowhosts.New: %v", err)
+		} else {
+			callback = cb
+		}
+	} else {
+		callback = ssh.InsecureIgnoreHostKey()
+	}
+
+	pkey, err := ioutil.ReadFile(privateKeyFile)
+	if err != nil {
+		return conf, fmt.Errorf("ioutil.ReadFile: %v", err)
+	}
+	signer, err := ssh.ParsePrivateKey(pkey)
+	if err != nil {
+		return conf, fmt.Errorf("ssh.ParsePrivateKey: %v", err)
+	}
+
+	return ssh.ClientConfig{
+		User:            remoteUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: callback,
+	}, nil
+}
+
+// hosts parsing utilities
+
+func ParseHostsList(path string, re *regexp.Regexp, formatter func(string) string) ([]string, error) {
+	var hosts []string
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open host list file: %v", err)
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		matches := re.FindSubmatch(scanner.Bytes())
+		if matches != nil {
+			host := formatter(string(matches[1]))
+			hosts = append(hosts, host)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanner error: %v", err)
+	}
+	return hosts, nil
+}
+
+func Append22(host string) string {
+	parts := strings.Split(host, ":")
+	if len(parts) == 1 {
+		return fmt.Sprintf("%s:%d", host, 22)
+	}
+	return host
+}
+
+// logging utilities
+
+type SyncLogger struct {
+	Logger *log.Logger
+	mu     sync.Mutex
+}
+
+func (l *SyncLogger) Info(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.Logger.Printf("INFO: %s", msg)
+}
+
+func (l *SyncLogger) Error(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.Logger.Printf("ERROR: %s", msg)
+}
+
+func (l *SyncLogger) Fatal(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.Logger.Fatalf("FATAL: %s", msg)
+	os.Exit(1)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -47,10 +47,10 @@ func NewSSHConfig(checkHostKey bool, knownHostsFile, privateKeyFile, remoteUser 
 	}, nil
 }
 
-// hosts parsing utilities
+// Hosts parsing utilities
 
-// ParseHostsList: uses the provided regex and formatter to return a list of hosts
-// regex interprets the first grouping as the host string to format + return
+// ParseHostsList: uses the provided regex and formatter to return a list of hosts.
+// Regex interprets the first grouping as the host string to format + return.
 func ParseHostsList(path string, re *regexp.Regexp, formatter func(string) string) ([]string, error) {
 	var hosts []string
 
@@ -72,7 +72,7 @@ func ParseHostsList(path string, re *regexp.Regexp, formatter func(string) strin
 	return hosts, nil
 }
 
-// Append22: return the host string with `:22` appended if not already present
+// Append22: return the host string with `:22` appended if not already present.
 func Append22(host string) string {
 	parts := strings.Split(host, ":")
 	res := host
@@ -91,7 +91,7 @@ func Append22(host string) string {
 	return res
 }
 
-// logging utilities
+// Logging utilities
 
 type SyncLogger struct {
 	Logger *log.Logger
@@ -111,7 +111,7 @@ func (l *SyncLogger) Error(msg string) {
 }
 
 func (l *SyncLogger) Fatal(msg string) {
+	// no need to Unlock since logger.Fatalf will call os.Exit(1) and terminate the program
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	l.Logger.Fatalf("FATAL: %s", msg)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -19,9 +19,9 @@ func TestNewSSHConfig(t *testing.T) {
 	pkey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	pkeyBytes := x509.MarshalPKCS1PrivateKey(pkey)
 	pkeyPEM := pem.Block{
-		Type: "RSA PRIVATE KEY",
+		Type:    "RSA PRIVATE KEY",
 		Headers: nil,
-		Bytes: pkeyBytes,
+		Bytes:   pkeyBytes,
 	}
 	_ = ioutil.WriteFile(tempKey, pem.EncodeToMemory(&pkeyPEM), 0600)
 
@@ -60,7 +60,7 @@ foo bar baz
 	if err := ioutil.WriteFile(fmt.Sprintf("%s/test-hosts.list", os.TempDir()), []byte(hosts), 0600); err != nil {
 		t.Fatalf("ioutil.WriteFile: %v", err)
 	}
-	defer func(){ _ = os.Remove(tempFile) }()
+	defer func() { _ = os.Remove(tempFile) }()
 	re, _ := regexp.Compile(`^([^\s]*)\b`)
 	{
 		got, err := ParseHostsList(tempFile, re, Append22)
@@ -94,7 +94,7 @@ func TestAppend22(t *testing.T) {
 
 type fakeAddr struct {
 	network string
-	host string
+	host    string
 }
 
 func (f fakeAddr) Network() string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestNewSSHConfig(t *testing.T) {
+	// create temp private key file
+	tempKey := fmt.Sprintf("%s/temp-key.pem", os.TempDir())
+	pkey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pkeyBytes := x509.MarshalPKCS1PrivateKey(pkey)
+	pkeyPEM := pem.Block{
+		Type: "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes: pkeyBytes,
+	}
+	_ = ioutil.WriteFile(tempKey, pem.EncodeToMemory(&pkeyPEM), 0600)
+
+	conf, err := NewSSHConfig(false, "/dev/null", tempKey, "foobar")
+	if err != nil {
+		t.Fatalf("NewSSHConfig: %v", err)
+	}
+	if got, want := conf.User, "foobar"; got != want {
+		t.Errorf("bad user: %v, want %v", got, want)
+	}
+	//pkeySigner, _ := ssh.ParsePrivateKey(pem.EncodeToMemory(&pkeyPEM))
+	//if got, want := conf.Auth[0], ssh.PublicKeys(pkeySigner); got != want {
+	//if diff := cmp.Diff(conf.Auth[0], ssh.PublicKeys(pkeySigner)); diff != "" {
+	//	t.Errorf("diff: %v", diff)
+	//}
+	{
+		var got error
+		var want error
+		if got, want = conf.HostKeyCallback("host", fakeAddr{}, nil), nil; got != want {
+			t.Errorf("HostKeyCallback should return nil, got: %v", got)
+		}
+	}
+}
+
+func TestParseHostsList(t *testing.T) {
+	// create temp host file
+	hosts := `
+1.1.1.1
+1.1.1.1:22
+1.2.3.4.5
+foo.bar.baz
+asdf
+foo bar baz
+`
+	tempFile := fmt.Sprintf("%s/test-hosts.list", os.TempDir())
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/test-hosts.list", os.TempDir()), []byte(hosts), 0600); err != nil {
+		t.Fatalf("ioutil.WriteFile: %v", err)
+	}
+	defer func(){ _ = os.Remove(tempFile) }()
+	re, _ := regexp.Compile(`^([^\s]*)\b`)
+	{
+		got, err := ParseHostsList(tempFile, re, Append22)
+		if err != nil {
+			t.Errorf("ParseHostsList: %v", err)
+		}
+		want := []string{"1.1.1.1:22", "1.1.1.1:22", "1.2.3.4.5:22", "foo.bar.baz:22", "asdf:22", "foo:22"}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("diff: %v", diff)
+		}
+	}
+}
+
+func TestAppend22(t *testing.T) {
+	if got, want := Append22("foo"), "foo:22"; got != want {
+		t.Errorf("got: %v, want %v", got, want)
+	}
+	if got, want := Append22("foo:22"), "foo:22"; got != want {
+		t.Errorf("got: %v, want %v", got, want)
+	}
+	if got, want := Append22("foo:"), "foo:22"; got != want {
+		t.Errorf("got: %v, want %v", got, want)
+	}
+	if got, want := Append22("http://foo:22"), "http://foo:22"; got != want {
+		t.Errorf("got: %v, want %v", got, want)
+	}
+	if got, want := Append22(""), ""; got != want {
+		t.Errorf("got: %v, want %v", got, want)
+	}
+}
+
+type fakeAddr struct {
+	network string
+	host string
+}
+
+func (f fakeAddr) Network() string {
+	return f.network
+}
+
+func (f fakeAddr) String() string {
+	return f.host
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,11 +6,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewSSHConfig(t *testing.T) {


### PR DESCRIPTION
This change factors out the remote-executor API into its own sub-directory. Utility functions are broken out into an adjacent sub-directory. 
This change also introduces unit tests both for the API and the utility functions.
main.go is now one possible implementation utilizing the API and utility functions. mian.go no longer encodes any functionality required for the APi to work (but it does show an example of how to live-stream results)